### PR TITLE
Display error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,10 +60,8 @@ const parseAuthHeader = function(string) {
 
 const unauthorizedResponse = function(body) {
   return new Response(
-    null, {
+    body, {
       status: 401,
-      statusText: "'Authentication required.'",
-      body: body,
       headers: {
         "WWW-Authenticate": 'Basic realm="User Visible Realm"'
       }


### PR DESCRIPTION
If the user cancels the authentication prompt, it should display the passed body (`Unauthorized`).

Also removed a redundant header `statusText`.

PS: The prompt does not display the `User Visible Realm` message due to browser implementations/bugs, nothing we can do there.